### PR TITLE
Fix #3 Remove weird mentionings of the word boto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # aws-export-assume-profile
 
-`aws-export-assume-profile` is a bash script that will output AWS export statements of your chosen aws boto profile. In case you have to manage multiple AWS accounts that rely on different boto profiles, you can *activate* a chosen profile by making it available in your shell environment.
+`aws-export-assume-profile` is a bash script that will output AWS export statements of your chosen aws profile. In case you have to manage multiple AWS accounts that rely on different profiles, you can *activate* a chosen profile by making it available in your shell environment.
 
-This tool requires `aws` cli and retrieves credentials via `aws sts assume-role`. If you are looking for a way to export boto profiles already present in `~/.aws/credentials` have a look at **[aws-export-profile](https://github.com/cytopia/aws-export-profile)**.
+This tool requires `aws` cli and retrieves credentials via `aws sts assume-role`. If you are looking for a way to export profiles already present in `~/.aws/credentials` have a look at **[aws-export-profile](https://github.com/cytopia/aws-export-profile)**.
 
 [![Build Status](https://travis-ci.org/cytopia/aws-export-assume-profile.svg?branch=master)](https://travis-ci.org/cytopia/aws-export-assume-profile)
 ![Release](https://img.shields.io/github/release/cytopia/aws-export-assume-profile.svg)
 
-**Note:** Wrap the command in **`$(aws-export-assume-profile)`** to actually export your boto environment variables.
+**Note:** Wrap the command in **`$(aws-export-assume-profile)`** to actually export your profiled environment variables.
 
 
 ## But why?
 
-Most AWS related tools support boto profiles out of the box, such as the `aws-cli` (Example: `aws ec2 --profile <BOTO_PROFILE>`). However sometimes it is required to have your chosen boto profile available as shell variables. One of the use cases is when you use Docker and want a specific boto login available inside your container.:
+Most AWS related tools support profiles out of the box, such as the `aws-cli` (Example: `aws ec2 --profile <AWS_PROFILE>`). However sometimes it is required to have your chosen aws profile available as shell variables. One of the use cases is when you use Docker and want a specific login available inside your container.:
 ```bash
-# Export staging boto profile
+# Export staging aws profile
 user> $(aws-export-assume-profile staging)
 
 # Make AWS login available inside your Docker container
@@ -46,7 +46,7 @@ The following export variables are currently supported.
 
 This tool simply output the exports to stdout. In order to auto-source them, wrap the command in **`$(...)`**.
 
-#### Boto profile `testing`
+#### AWS profile `testing`
 
 ```bash
 user> aws-export-assume-profile testing
@@ -58,7 +58,7 @@ export AWS_SECRET_KEY="A1Bc/XXXXXXXXXXXXXXXXXXXXXXXXXXX"
 export AWS_REGION="eu-central-1"
 ```
 
-#### Boto profile `testing` with custom paths
+#### AWS profile `testing` with custom paths
 
 ```bash
 user> aws-export-assume-profile deploy /jenkins/aws/config
@@ -70,7 +70,7 @@ export AWS_SECRET_KEY="A1Bc/XXXXXXXXXXXXXXXXXXXXXXXXXXX"
 export AWS_REGION="eu-central-1"
 ```
 
-#### Boto profile `production` with more exports
+#### AWS profile `production` with more exports
 ```bash
 user> aws-export-assume-profile production
 
@@ -82,7 +82,7 @@ export AWS_SESSION_TOKEN="XXXXXXXXXXXXXXXXx/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/XXXXX
 export AWS_REGION="eu-central-1"
 ```
 
-#### Export boto profile `production`
+#### Export AWS profile `production`
 ```bash
 user> $(aws-export-assume-profile production)
 
@@ -111,11 +111,11 @@ Usage: aws-export-assume-profile [profile] [config]
        aws-export-assume-profile --help|-h
        aws-export-assume-profile --version|-v
 
-This bash helper will output AWS export statements of your chosen aws boto profile.
+This bash helper will output AWS export statements of your chosen aws profile.
 Wrap this script in $(aws-export-assume-profile) to export those environment variables.
 
 Optional parameter:
-    [profile]      Boto profile name to export. Default is 'default'
+    [profile]      AWS profile name to export. Default is 'default'
     [config]       Path to your aws config file.
                    If no config file is found, AWS_REGION export will not be available.
                    Default is ~/.aws/config

--- a/aws-export-assume-profile
+++ b/aws-export-assume-profile
@@ -23,6 +23,7 @@ CONFIG="${2:-${HOME}/.aws/config}"
 ROLE_ARN=
 SOURCE_PROFILE=
 REGION=
+DURATION_SECONDS=3600
 
 
 # --------------------------------------------------------------------------------
@@ -66,7 +67,7 @@ function json_get_key {
 ### Extract AWS profile information
 ###
 ### @param   config  Path to .aws/config
-### @param   profile Name of AWS boto profile
+### @param   profile Name of AWS profile
 ### @returns         Success if profile was found, otherwise failure
 ###
 function extract_aws_profile {
@@ -109,6 +110,10 @@ function extract_aws_profile {
 			if [[ "${line}" =~ ^[[:space:]]*region[[:space:]]*= ]]; then
 				REGION="${line#*=}"
 			fi
+			# Get Login duration
+			if [[ "${line}" =~ ^[[:space:]]*duration_seconds[[:space:]]*= ]]; then
+				DURATION_SECONDS="${line#*=}"
+			fi
 		fi
 	done < "${config}"
 
@@ -147,11 +152,11 @@ Usage: aws-export-assume-profile [profile] [config]
        aws-export-assume-profile --help, -h
        aws-export-assume-profile --version, -v
 
-This bash helper will output AWS export statements of your chosen aws boto profile.
+This bash helper will output AWS export statements of your chosen aws profile.
 Wrap this script in \$(aws-export-assume-profile) to export those environment variables.
 
 Optional parameter:
-    [profile]      Boto profile name to export. Default is 'default'
+    [profile]      AWS profile name to export. Default is 'default'
     [config]       Path to your aws config file.
                    If no config file is found, AWS_REGION export will not be available.
                    Default is ~/.aws/config
@@ -219,6 +224,7 @@ OUTPUT="$(
 	aws sts assume-role \
 		--profile "${SOURCE_PROFILE}" \
 		--role-arn "${ROLE_ARN}" \
+		--duration-seconds "${DURATION_SECONDS}" \
 		--role-session-name "${PROFILE}"
 )"
 


### PR DESCRIPTION
# Remove weird mentionings of the word boto

* Fixes https://github.com/cytopia/aws-export-assume-profile/issues/3

```bash
$ grep -ic boto aws-export-assume-profile README.md

aws-export-assume-profile:0
README.md:0
```

Thanks @keen99 for hinting.